### PR TITLE
fix branch name

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -2,9 +2,9 @@ name: Django CI
 
 on:
   push:
-    branches: [ "testing" ]
+    branches: [ "develop" ]
   pull_request:
-    branches: [ "testing" ]
+    branches: [ "develop" ]
 
 jobs:
   build:


### PR DESCRIPTION
De naam van de branch moet develop zijn. Op de testing branch moest dat testing zijn. Daarom dat de naam er nu nog fout staat voor de huidige branch