### PR TITLE
Kleine fix

### DIFF
--- a/api/middleware.py
+++ b/api/middleware.py
@@ -25,7 +25,7 @@ class RedirectAnonymousUserMiddleware:
         if request.user.is_anonymous and request.path not in [
             "/oauth2/login",
             "/oauth2/callback",
-            "/.well-known/microsoft-identity-association.json"
+            "/.well-known/microsoft-identity-association.json",
         ]:
             # Redirect to the login page
             return redirect(settings.LOGIN_URL)

--- a/api/tests/views/test_project.py
+++ b/api/tests/views/test_project.py
@@ -48,7 +48,7 @@ class ProjectListViewTest(APITestCase):
             "beschrijving": "Dit is een test project.",
             "opgave_bestand": SimpleUploadedFile("file.txt", b"file_content"),
             "vak": vak,
-            "deadline": "2024-03-31T12:40:05.317980Z",
+            "deadline": "2024-12-31T00:00:00.000000Z",
             "extra_deadline": "",
             "max_score": 20,
             "zichtbaar": "true",


### PR DESCRIPTION
Zorgt ervoor dat het microsoft identity association bestand niet redirect naar de login pagina. 
Dit was nodig om onze frontend applicatie te registreren op microsoft Entra.