### PR TITLE
Groep consistency patch

### DIFF
--- a/frontend/frontend/src/components/GroupAccessComponent.tsx
+++ b/frontend/frontend/src/components/GroupAccessComponent.tsx
@@ -1,8 +1,6 @@
 import { Button } from './CustomComponents'
-import { Box, Typography } from '@mui/material'
+import { Box } from '@mui/material'
 import { t } from 'i18next'
-import Switch from '@mui/material/Switch'
-import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 interface GroupAccessComponentProps {
@@ -20,16 +18,11 @@ export function GroupAccessComponent({
     courseid,
 }: GroupAccessComponentProps) {
     const navigate = useNavigate()
-    const [allowGroups, setAllowGroups] = useState(false)
 
     // Handle click event to navigate to the groups page
     const handleClick = () => {
         navigate(`/course/${courseid}/assignment/${assignmentid}/groups`)
     }
-
-    useEffect(() => {
-        //set max group size to 1 if groups are not allowed and register all students to a group of their own
-    }, [allowGroups])
 
     return (
         <>
@@ -42,20 +35,7 @@ export function GroupAccessComponent({
                 marginBottom={2}
             >
                 {/* Button to navigate to groups page */}
-                {allowGroups ? (
-                    <Button onClick={handleClick}>{t('groups')}</Button>
-                ) : (
-                    // Show text indicating groups are not allowed
-                    <Typography color={'text.primary'} variant={'body1'}>
-                        {t('groups')}
-                    </Typography>
-                )}
-                {/* Switch to toggle group access */}
-                <Switch
-                    checked={allowGroups}
-                    onChange={() => setAllowGroups(!allowGroups)}
-                    color={'primary'}
-                />
+                <Button onClick={handleClick}>{t('groups')}</Button>
             </Box>
         </>
     )

--- a/frontend/frontend/src/i18n/en.ts
+++ b/frontend/frontend/src/i18n/en.ts
@@ -109,6 +109,9 @@ const english = {
     email: 'email',
     copy_invite: 'Copy invitation link',
     n_of_members: 'Max Amount Of Members',
+    existing_submissions:
+        'This could impact existing submissions. Are you sure?',
+    divide_groups: 'Divide Groups',
 }
 
 export default english

--- a/frontend/frontend/src/i18n/en.ts
+++ b/frontend/frontend/src/i18n/en.ts
@@ -107,7 +107,8 @@ const english = {
     acces: 'This gives you access to the course.',
     deadlines_on: 'Deadlines on',
     email: 'email',
-    copy_invite: 'Copy invitation link'
+    copy_invite: 'Copy invitation link',
+    n_of_members: 'Max Amount Of Members',
 }
 
 export default english

--- a/frontend/frontend/src/i18n/nl.ts
+++ b/frontend/frontend/src/i18n/nl.ts
@@ -109,6 +109,9 @@ const dutch = {
     email: 'email',
     copy_invite: 'Kopieer uitnodigingslink',
     n_of_members: 'Max Aantal Leden',
+    existing_submissions:
+        'Dit kan invloed hebben op bestaande indieningen. Weet je het zeker?',
+    divide_groups: 'Verdeel Groepen',
 }
 
 export default dutch

--- a/frontend/frontend/src/i18n/nl.ts
+++ b/frontend/frontend/src/i18n/nl.ts
@@ -107,7 +107,8 @@ const dutch = {
     acces: 'Dit geeft je toegang tot het vak.',
     deadlines_on: 'Deadlines op',
     email: 'email',
-    copy_invite: 'Kopieer uitnodigingslink'
+    copy_invite: 'Kopieer uitnodigingslink',
+    n_of_members: 'Max Aantal Leden',
 }
 
 export default dutch

--- a/frontend/frontend/src/pages/addChangeAssignmentPage/AddChangeAssignmentPage.tsx
+++ b/frontend/frontend/src/pages/addChangeAssignmentPage/AddChangeAssignmentPage.tsx
@@ -99,6 +99,7 @@ export function AddChangeAssignmentPage() {
     const [maxScore, SetMaxScore] = useState<number>(20)
     const [cleared, setCleared] = useState<boolean>(false)
     const [filename, setFilename] = useState<string>('indiening.zip')
+    const [groupSize, setGroupSize] = useState<number>(1)
 
     // State for the error checks of the assignment
     const [assignmentErrors, setAssignmentErrors] = useState<errorChecks>({
@@ -183,15 +184,11 @@ export function AddChangeAssignmentPage() {
 
                     setVisible(assignment.zichtbaar)
                     if (assignment.deadline !== null) {
-                        setDueDate(
-                            dayjs(assignment.deadline)
-                        )
+                        setDueDate(dayjs(assignment.deadline))
                         console.log('deadline' + assignment.deadline)
                     }
                     if (assignment.extra_deadline !== null) {
-                        setExtraDueDate(
-                            dayjs(assignment.extra_deadline)
-                        )
+                        setExtraDueDate(dayjs(assignment.extra_deadline))
                         console.log(
                             'extra deadline' + assignment.extra_deadline
                         )
@@ -380,6 +377,7 @@ export function AddChangeAssignmentPage() {
         if (extraDueDate !== null) {
             formData.append('extra_deadline', extraDueDate.format())
         }
+        formData.append('max_groep_grootte', groupSize.toString())
 
         const config = {
             headers: {
@@ -540,7 +538,7 @@ export function AddChangeAssignmentPage() {
                         </Box>
                     </Box>
                     {/* Deadline section.
-                    There is both the normal deadline, 
+                    There is both the normal deadline,
                     and an extra deadline in case people need more time. */}
                     <Box
                         aria-label={'deadline'}
@@ -840,6 +838,44 @@ export function AddChangeAssignmentPage() {
                                     </IconButton>
                                 </Tooltip>
                             </Box>
+                            {/* change group size allowed, no need for extra group switch*/}
+                            {!assignmentId && (
+                                <Box
+                                    aria-label={'groupSize'}
+                                    display={'flex'}
+                                    flexDirection={'row'}
+                                    gap={1}
+                                    height={40}
+                                    alignItems={'center'}
+                                >
+                                    <Typography
+                                        fontWeight={'bold'}
+                                        color={'text.primary'}
+                                    >
+                                        {t('n_of_members')}
+                                    </Typography>
+                                    {loading ? (
+                                        <Skeleton
+                                            variant={'text'}
+                                            width={60}
+                                            height={60}
+                                        />
+                                    ) : (
+                                        <TextField
+                                            sx={{ width: 80 }}
+                                            label={'Group Size'}
+                                            type={'number'}
+                                            required
+                                            value={groupSize}
+                                            onChange={(event) =>
+                                                setGroupSize(
+                                                    parseInt(event.target.value)
+                                                )
+                                            }
+                                        />
+                                    )}
+                                </Box>
+                            )}
                             {/* This section allows the teacher to set the maximum score for the assignment.*/}
                             <Box
                                 aria-label={'maxScore'}

--- a/frontend/frontend/src/pages/assignmentPage/AssignmentPage.tsx
+++ b/frontend/frontend/src/pages/assignmentPage/AssignmentPage.tsx
@@ -336,12 +336,20 @@ export function AssignmentPage() {
                                             }}
                                         />
                                     ) : (
-                                        <GroupAccessComponent
-                                            assignmentid={parseInt(
-                                                assignmentId
+                                        <>
+                                            {(assignment?.max_groep_grootte
+                                                ? assignment.max_groep_grootte
+                                                : 1) > 1 && (
+                                                <GroupAccessComponent
+                                                    assignmentid={parseInt(
+                                                        assignmentId
+                                                    )}
+                                                    courseid={parseInt(
+                                                        courseId
+                                                    )}
+                                                />
                                             )}
-                                            courseid={parseInt(courseId)}
-                                        />
+                                        </>
                                     )}
                                 </Box>
 

--- a/frontend/frontend/src/pages/groupsPage/GroupsPage.tsx
+++ b/frontend/frontend/src/pages/groupsPage/GroupsPage.tsx
@@ -2,12 +2,12 @@ import { Header } from '../../components/Header.tsx'
 import { Button } from '../../components/CustomComponents.tsx'
 import {
     Box,
+    CircularProgress,
     Grid,
     IconButton,
     MenuItem,
     Select,
     SelectChangeEvent,
-    CircularProgress,
     Skeleton,
     Stack,
     Table,
@@ -31,7 +31,7 @@ import { Add } from '@mui/icons-material'
 import ClearIcon from '@mui/icons-material/Clear'
 import SaveIcon from '@mui/icons-material/Save'
 import WarningPopup from '../../components/WarningPopup.tsx'
-import { User } from '../subjectsPage/AddChangeSubjectPage.tsx' 
+import { User } from '../subjectsPage/AddChangeSubjectPage.tsx'
 
 // group interface
 export interface Group {
@@ -39,6 +39,8 @@ export interface Group {
     studenten: number[]
     project: number
 }
+
+//FIXME: groupsize should not be signed after creation of project, refactor!
 
 // Typescript typing for hashmap
 type Hashmap = Map<number, string>
@@ -414,149 +416,126 @@ export function GroupsPage() {
                 <>
                     {user?.is_lesgever ? (
                         // Rendering UI for teacher
-                    <>
-                        <Box
-                            component={'form'}
-                            onSubmit={handleSave}
-                            sx={{
-                                backgroundColor: 'background.default',
-                                height: '100%',
-                                width: '100%',
-                                display: 'flex',
-                                flexDirection: 'column',
-                                justifyContent: 'flex-start',
-                            }}
-                        >
-                            <Header
-                                variant={'default'}
-                                title={loading ? '' : `${projectName}: ${t('groups')}`}
-                            ></Header>
-                            <Stack
-                                marginTop={12}
-                                direction={'column'}
-                                spacing={4}
+                        <>
+                            <Box
+                                component={'form'}
+                                onSubmit={handleSave}
                                 sx={{
-                                    width: '100%',
-                                    height: '70 %',
                                     backgroundColor: 'background.default',
+                                    height: '100%',
+                                    width: '100%',
+                                    display: 'flex',
+                                    flexDirection: 'column',
+                                    justifyContent: 'flex-start',
                                 }}
                             >
-                                <Box>
-                                    <Box
-                                        sx={{
-                                            gap: 5,
-                                            padding: '20px',
-                                            backgroundColor: 'background.default',
-                                        }}
-                                    >
-                                        <Typography
-                                            variant="h5"
-                                            sx={{ fontWeight: 'bold' }}
-                                            color="text.primary"
+                                <Header
+                                    variant={'default'}
+                                    title={
+                                        loading
+                                            ? ''
+                                            : `${projectName}: ${t('groups')}`
+                                    }
+                                ></Header>
+                                <Stack
+                                    marginTop={12}
+                                    direction={'column'}
+                                    spacing={4}
+                                    sx={{
+                                        width: '100%',
+                                        height: '70 %',
+                                        backgroundColor: 'background.default',
+                                    }}
+                                >
+                                    <Box>
+                                        <Box
+                                            sx={{
+                                                gap: 5,
+                                                padding: '20px',
+                                                backgroundColor:
+                                                    'background.default',
+                                            }}
                                         >
-                                            {t('groups')}
-                                        </Typography>
-                                        <Stack direction={'row'}>
-                                            <Grid container spacing={2} alignItems="center">
-                                                <Grid item>
-                                                    <Typography
-                                                        color="text.primary"
-                                                        fontWeight={'bold'}
-                                                    >
-                                                        {t('amount')} {t('members')}/
-                                                        {t('group')}
-                                                    </Typography>
-                                                </Grid>
-                                                <Grid item minWidth={3}>
-                                                    {loading ? (
-                                                        <Skeleton
-                                                            variant={'text'}
-                                                            width={80}
-                                                            height={80}
-                                                        />
-                                                    ) : (
-                                                        <TextField
-                                                            // The teacher can specify the maximum group size
-                                                            // If a number smaller than 1 is entered, the input will be ignored
-                                                            aria-label={'maxGroupSize'}
-                                                            value={newGroupSize}
-                                                            type={'number'}
-                                                            onChange={(newValue) => {
-                                                                if (
-                                                                    parseInt(
-                                                                        newValue.target
-                                                                            .value
-                                                                    ) < 1
-                                                                )
-                                                                    return
-                                                                handleGroupSizeChange(
-                                                                    parseInt(
-                                                                        newValue.target
-                                                                            .value
-                                                                    )
-                                                                )
-                                                            }}
-                                                            variant="outlined"
-                                                            sx={{ width: 80 }}
-                                                        />
-                                                    )}
-                                                </Grid>
-                                            </Grid>
-                                        </Stack>
-                                        <Stack
-                                            direction="row"
-                                            alignItems="center"
-                                            spacing={10}
-                                            marginY={6}
-                                        >
-                                            {loading ? (
-                                                <Skeleton
-                                                    variant={'rectangular'}
-                                                    width={220}
-                                                    height={45}
-                                                    sx={{
-                                                        backgroundColor: 'secondary.main',
-                                                        borderRadius: 1,
-                                                    }}
-                                                />
-                                            ) : (
-                                                <Button
-                                                    // If a teacher doesn't want to create groups manually,
-                                                    // they can randomize the groups with a single click.variant={'contained'}
-                                                    disableElevation
-                                                    sx={{
-                                                        backgroundColor: 'secondary.main',
-                                                        padding: 1,
-                                                    }}
-                                                    onClick={randomGroups}
-                                                >
-                                                    <Typography
-                                                        color="text.primary"
-                                                        fontWeight={'bold'}
-                                                    >
-                                                        {t('random')} {t('groups')}
-                                                    </Typography>
-                                                </Button>
-                                            )}
-                                            <Box
-                                                // If the students are allowed to choose their own groups,
-                                                // the teacher can enable this feature with a switch.
-                                                display={'flex'}
-                                                flexDirection={'row'}
-                                                alignItems={'center'}
-                                                gap={2}
+                                            <Typography
+                                                variant="h5"
+                                                sx={{ fontWeight: 'bold' }}
+                                                color="text.primary"
                                             >
-                                                <Typography
-                                                    color="text.primary"
-                                                    fontWeight={'bold'}
+                                                {t('groups')}
+                                            </Typography>
+                                            <Stack direction={'row'}>
+                                                <Grid
+                                                    container
+                                                    spacing={2}
+                                                    alignItems="center"
                                                 >
-                                                    {t('students_choose')}
-                                                </Typography>
+                                                    <Grid item>
+                                                        <Typography
+                                                            color="text.primary"
+                                                            fontWeight={'bold'}
+                                                        >
+                                                            {t('amount')}{' '}
+                                                            {t('members')}/
+                                                            {t('group')}
+                                                        </Typography>
+                                                    </Grid>
+                                                    <Grid item minWidth={3}>
+                                                        {loading ? (
+                                                            <Skeleton
+                                                                variant={'text'}
+                                                                width={80}
+                                                                height={80}
+                                                            />
+                                                        ) : (
+                                                            <TextField
+                                                                // The teacher can specify the maximum group size
+                                                                // If a number smaller than 1 is entered, the input will be ignored
+                                                                aria-label={
+                                                                    'maxGroupSize'
+                                                                }
+                                                                value={
+                                                                    newGroupSize
+                                                                }
+                                                                type={'number'}
+                                                                onChange={(
+                                                                    newValue
+                                                                ) => {
+                                                                    if (
+                                                                        parseInt(
+                                                                            newValue
+                                                                                .target
+                                                                                .value
+                                                                        ) < 1
+                                                                    )
+                                                                        return
+                                                                    handleGroupSizeChange(
+                                                                        parseInt(
+                                                                            newValue
+                                                                                .target
+                                                                                .value
+                                                                        )
+                                                                    )
+                                                                }}
+                                                                variant="outlined"
+                                                                sx={{
+                                                                    width: 80,
+                                                                }}
+                                                            />
+                                                        )}
+                                                    </Grid>
+                                                </Grid>
+                                            </Stack>
+                                            <Stack
+                                                direction="row"
+                                                alignItems="center"
+                                                spacing={10}
+                                                marginY={6}
+                                            >
                                                 {loading ? (
                                                     <Skeleton
                                                         variant={'rectangular'}
-                                                        width={40}
-                                                        height={30}
+                                                        width={220}
+                                                        height={45}
                                                         sx={{
                                                             backgroundColor:
                                                                 'secondary.main',
@@ -564,212 +543,132 @@ export function GroupsPage() {
                                                         }}
                                                     />
                                                 ) : (
-                                                    <Switch />
+                                                    <Button
+                                                        // If a teacher doesn't want to create groups manually,
+                                                        // they can randomize the groups with a single click.variant={'contained'}
+                                                        disableElevation
+                                                        sx={{
+                                                            backgroundColor:
+                                                                'secondary.main',
+                                                            padding: 1,
+                                                        }}
+                                                        onClick={randomGroups}
+                                                    >
+                                                        <Typography
+                                                            color="text.primary"
+                                                            fontWeight={'bold'}
+                                                        >
+                                                            {t('random')}{' '}
+                                                            {t('groups')}
+                                                        </Typography>
+                                                    </Button>
                                                 )}
-                                            </Box>
-                                        </Stack>
-                                    </Box>
+                                                <Box
+                                                    // If the students are allowed to choose their own groups,
+                                                    // the teacher can enable this feature with a switch.
+                                                    display={'flex'}
+                                                    flexDirection={'row'}
+                                                    alignItems={'center'}
+                                                    gap={2}
+                                                >
+                                                    <Typography
+                                                        color="text.primary"
+                                                        fontWeight={'bold'}
+                                                    >
+                                                        {t('students_choose')}
+                                                    </Typography>
+                                                    {loading ? (
+                                                        <Skeleton
+                                                            variant={
+                                                                'rectangular'
+                                                            }
+                                                            width={40}
+                                                            height={30}
+                                                            sx={{
+                                                                backgroundColor:
+                                                                    'secondary.main',
+                                                                borderRadius: 1,
+                                                            }}
+                                                        />
+                                                    ) : (
+                                                        <Switch />
+                                                    )}
+                                                </Box>
+                                            </Stack>
+                                        </Box>
 
-                                    <Box
-                                        sx={{
-                                            marginTop: -3,
-                                            padding: '20px',
-                                            backgroundColor: 'background.default',
-                                        }}
-                                    >
                                         <Box
-                                            aria-label={'group_assigner'}
-                                            display={'flex'}
-                                            flexDirection={'row'}
-                                            maxWidth={500}
-                                            justifyContent={'space-between'}
-                                            alignItems={'flex-start'}
+                                            sx={{
+                                                marginTop: -3,
+                                                padding: '20px',
+                                                backgroundColor:
+                                                    'background.default',
+                                            }}
                                         >
-                                            <TableContainer sx={{ maxHeight: '55vh' }}>
-                                                <Table
-                                                    // The teacher can see the available students
-                                                    // on the left side of the screen.
-                                                    // They are displayed in a table with a sticky header.aria-label={'studentTable'}
-                                                    stickyHeader
+                                            <Box
+                                                aria-label={'group_assigner'}
+                                                display={'flex'}
+                                                flexDirection={'row'}
+                                                maxWidth={500}
+                                                justifyContent={'space-between'}
+                                                alignItems={'flex-start'}
+                                            >
+                                                <TableContainer
+                                                    sx={{ maxHeight: '55vh' }}
                                                 >
-                                                    <TableHead>
-                                                        <TableRow>
-                                                            <TableCell>
-                                                                <Typography
-                                                                    fontWeight={'bold'}
-                                                                >
-                                                                    {t('students')}
-                                                                </Typography>
-                                                            </TableCell>
-                                                        </TableRow>
-                                                    </TableHead>
-                                                    <TableBody>
-                                                        {loading ? (
-                                                            [...Array(3)].map(
-                                                                (_, index) => (
-                                                                    <Skeleton
-                                                                        key={index}
-                                                                        variant="text"
-                                                                        width={'100%'}
-                                                                        height={50}
-                                                                        sx={{ margin: 0 }}
-                                                                    />
-                                                                )
-                                                            )
-                                                        ) : (
-                                                            <>
-                                                                {availableStudents.map(
-                                                                    (student) => (
-                                                                        <TableRow
-                                                                            key={student}
-                                                                        >
-                                                                            <TableCell
-                                                                                sx={{
-                                                                                    height: 20,
-                                                                                    display:
-                                                                                        'flex',
-                                                                                    flexDirection:
-                                                                                        'row',
-                                                                                    justifyContent:
-                                                                                        'space-between',
-                                                                                    alignItems:
-                                                                                        'center',
-                                                                                }}
-                                                                            >
-                                                                                {studentNames.get(
-                                                                                    student
-                                                                                ) === ''
-                                                                                    ? student
-                                                                                    : studentNames.get(
-                                                                                        student
-                                                                                    )}
-                                                                                <IconButton // people can be added to groups by clicking on the plus icon
-                                                                                    disabled={
-                                                                                        newGroups[
-                                                                                            parseInt(
-                                                                                                currentGroup
-                                                                                            )
-                                                                                        ]
-                                                                                            ? newGroups[
-                                                                                                parseInt(
-                                                                                                    currentGroup
-                                                                                                )
-                                                                                            ]
-                                                                                                .studenten
-                                                                                                .length >=
-                                                                                            newGroupSize
-                                                                                            : true
-                                                                                    }
-                                                                                    onClick={() => {
-                                                                                        assignStudent(
-                                                                                            student,
-                                                                                            parseInt(
-                                                                                                currentGroup
-                                                                                            )
-                                                                                        )
-                                                                                    }}
-                                                                                >
-                                                                                    <Add />
-                                                                                </IconButton>
-                                                                            </TableCell>
-                                                                        </TableRow>
-                                                                    )
-                                                                )}
-                                                            </>
-                                                        )}
-                                                    </TableBody>
-                                                </Table>
-                                            </TableContainer>
-                                            <TableContainer sx={{ maxHeight: '55vh' }}>
-                                                <Table
-                                                    // The teacher can see the students in the specified group
-                                                    // on the right side of the screen.
-                                                    aria-label={'groupTable'}
-                                                    stickyHeader
-                                                    sx={{ maxHeight: '5    0svh' }}
-                                                >
-                                                    <TableHead>
-                                                        <TableRow>
-                                                            <TableCell>
-                                                                <Typography
-                                                                    fontWeight={'bold'}
-                                                                >
-                                                                    {t('group')}
-                                                                </Typography>
-                                                                {loading ? (
-                                                                    <Skeleton
-                                                                        variant="text"
-                                                                        width={'80%'}
-                                                                        height={70}
-                                                                        sx={{ margin: 0 }}
-                                                                    />
-                                                                ) : (
-                                                                    <>
-                                                                        <Select
-                                                                            // The teacher can select a group from the dropdown menu
-                                                                            aria-label={
-                                                                                'groupSelect'
+                                                    <Table
+                                                        // The teacher can see the available students
+                                                        // on the left side of the screen.
+                                                        // They are displayed in a table with a sticky header.aria-label={'studentTable'}
+                                                        stickyHeader
+                                                    >
+                                                        <TableHead>
+                                                            <TableRow>
+                                                                <TableCell>
+                                                                    <Typography
+                                                                        fontWeight={
+                                                                            'bold'
+                                                                        }
+                                                                    >
+                                                                        {t(
+                                                                            'students'
+                                                                        )}
+                                                                    </Typography>
+                                                                </TableCell>
+                                                            </TableRow>
+                                                        </TableHead>
+                                                        <TableBody>
+                                                            {loading ? (
+                                                                [
+                                                                    ...Array(3),
+                                                                ].map(
+                                                                    (
+                                                                        _,
+                                                                        index
+                                                                    ) => (
+                                                                        <Skeleton
+                                                                            key={
+                                                                                index
                                                                             }
-                                                                            value={
-                                                                                currentGroup
+                                                                            variant="text"
+                                                                            width={
+                                                                                '100%'
+                                                                            }
+                                                                            height={
+                                                                                50
                                                                             }
                                                                             sx={{
-                                                                                width: 200,
+                                                                                margin: 0,
                                                                             }}
-                                                                            onChange={
-                                                                                handleCurrentGroupChange
-                                                                            }
-                                                                            label={t(
-                                                                                'group'
-                                                                            )}
-                                                                        >
-                                                                            {newGroups.map(
-                                                                                (
-                                                                                    _,
-                                                                                    index
-                                                                                ) => (
-                                                                                    <MenuItem
-                                                                                        key={index.toString()}
-                                                                                        value={index.toString()}
-                                                                                    >
-                                                                                        {t(
-                                                                                            'group'
-                                                                                        ) +
-                                                                                            (index +
-                                                                                                1)}
-                                                                                    </MenuItem>
-                                                                                )
-                                                                            )}
-                                                                        </Select>
-                                                                    </>
-                                                                )}
-                                                            </TableCell>
-                                                        </TableRow>
-                                                    </TableHead>
-                                                    <TableBody>
-                                                        {loading ? (
-                                                            [...Array(3)].map(
-                                                                (_, index) => (
-                                                                    <Skeleton
-                                                                        key={index}
-                                                                        variant="text"
-                                                                        width={'100%'}
-                                                                        height={50}
-                                                                        sx={{ margin: 0 }}
-                                                                    />
+                                                                        />
+                                                                    )
                                                                 )
-                                                            )
-                                                        ) : (
-                                                            <>
-                                                                {newGroups[
-                                                                    parseInt(currentGroup)
-                                                                ] &&
-                                                                    newGroups[
-                                                                        parseInt(
-                                                                            currentGroup
-                                                                        )
-                                                                    ].studenten.map(
-                                                                        (student) => (
+                                                            ) : (
+                                                                <>
+                                                                    {availableStudents.map(
+                                                                        (
+                                                                            student
+                                                                        ) => (
                                                                             <TableRow
                                                                                 key={
                                                                                     student
@@ -790,10 +689,31 @@ export function GroupsPage() {
                                                                                 >
                                                                                     {studentNames.get(
                                                                                         student
-                                                                                    )}
-                                                                                    <IconButton // The teacher can remove students from the group by clicking on the cross icon
+                                                                                    ) ===
+                                                                                    ''
+                                                                                        ? student
+                                                                                        : studentNames.get(
+                                                                                              student
+                                                                                          )}
+                                                                                    <IconButton // people can be added to groups by clicking on the plus icon
+                                                                                        disabled={
+                                                                                            newGroups[
+                                                                                                parseInt(
+                                                                                                    currentGroup
+                                                                                                )
+                                                                                            ]
+                                                                                                ? newGroups[
+                                                                                                      parseInt(
+                                                                                                          currentGroup
+                                                                                                      )
+                                                                                                  ]
+                                                                                                      .studenten
+                                                                                                      .length >=
+                                                                                                  newGroupSize
+                                                                                                : true
+                                                                                        }
                                                                                         onClick={() => {
-                                                                                            removeStudent(
+                                                                                            assignStudent(
                                                                                                 student,
                                                                                                 parseInt(
                                                                                                     currentGroup
@@ -801,97 +721,286 @@ export function GroupsPage() {
                                                                                             )
                                                                                         }}
                                                                                     >
-                                                                                        <CancelIcon />
+                                                                                        <Add />
                                                                                     </IconButton>
                                                                                 </TableCell>
                                                                             </TableRow>
                                                                         )
                                                                     )}
-                                                            </>
-                                                        )}
-                                                    </TableBody>
-                                                </Table>
-                                            </TableContainer>
-                                        </Box>
-                                    </Box>
-                                </Box>
-                            </Stack>
-                            <Box
-                                aria-label={'save/cancel'}
-                                sx={{
-                                    position: 'fixed',
-                                    bottom: 0,
-                                    width: '100%',
-                                    alignItems: 'flex-end',
-                                    gap: 5,
-                                    paddingRight: 10,
-                                }}
-                            >
-                                <DialogActions>
-                                    <Box pr={5} pb={5} display={'flex'} gap={1}>
-                                        <Tooltip title={t('cancel')}>
-                                            <IconButton
-                                                // The teacher can cancel the group changes by clicking on the cross icon.
-                                                onClick={handleCancel}
-                                                sx={{
-                                                    backgroundColor: 'secondary.main',
-                                                    borderRadius: 2,
-                                                }}
-                                            >
-                                                <ClearIcon fontSize={'medium'} />
-                                            </IconButton>
-                                        </Tooltip>
-                                        <Tooltip title={t('submit')}>
-                                            {loading ? (
-                                                <Skeleton
-                                                    variant={'rectangular'}
-                                                    width={40}
-                                                    height={40}
-                                                    sx={{
-                                                        backgroundColor: 'primary.main',
-                                                        borderRadius: 2,
-                                                    }}
-                                                />
-                                            ) : (
-                                                <>
-                                                    <IconButton
-                                                        // The teacher can save the group changes by clicking on the save icon.type="submit"
-                                                        aria-label={'submit'}
-                                                        type={'submit'}
+                                                                </>
+                                                            )}
+                                                        </TableBody>
+                                                    </Table>
+                                                </TableContainer>
+                                                <TableContainer
+                                                    sx={{ maxHeight: '55vh' }}
+                                                >
+                                                    <Table
+                                                        // The teacher can see the students in the specified group
+                                                        // on the right side of the screen.
+                                                        aria-label={
+                                                            'groupTable'
+                                                        }
+                                                        stickyHeader
                                                         sx={{
-                                                            backgroundColor: 'primary.main',
-                                                            borderRadius: 2,
-                                                            color: 'background.default',
-                                                            '&:hover': {
-                                                                backgroundColor:
-                                                                    'secondary.main',
-                                                                color: 'text.primary',
-                                                            },
+                                                            maxHeight:
+                                                                '5    0svh',
                                                         }}
                                                     >
-                                                        <SaveIcon fontSize={'medium'} />
-                                                    </IconButton>
-                                                </>
-                                            )}
-                                        </Tooltip>
+                                                        <TableHead>
+                                                            <TableRow>
+                                                                <TableCell>
+                                                                    <Typography
+                                                                        fontWeight={
+                                                                            'bold'
+                                                                        }
+                                                                    >
+                                                                        {t(
+                                                                            'group'
+                                                                        )}
+                                                                    </Typography>
+                                                                    {loading ? (
+                                                                        <Skeleton
+                                                                            variant="text"
+                                                                            width={
+                                                                                '80%'
+                                                                            }
+                                                                            height={
+                                                                                70
+                                                                            }
+                                                                            sx={{
+                                                                                margin: 0,
+                                                                            }}
+                                                                        />
+                                                                    ) : (
+                                                                        <>
+                                                                            <Select
+                                                                                // The teacher can select a group from the dropdown menu
+                                                                                aria-label={
+                                                                                    'groupSelect'
+                                                                                }
+                                                                                value={
+                                                                                    currentGroup
+                                                                                }
+                                                                                sx={{
+                                                                                    width: 200,
+                                                                                }}
+                                                                                onChange={
+                                                                                    handleCurrentGroupChange
+                                                                                }
+                                                                                label={t(
+                                                                                    'group'
+                                                                                )}
+                                                                            >
+                                                                                {newGroups.map(
+                                                                                    (
+                                                                                        _,
+                                                                                        index
+                                                                                    ) => (
+                                                                                        <MenuItem
+                                                                                            key={index.toString()}
+                                                                                            value={index.toString()}
+                                                                                        >
+                                                                                            {t(
+                                                                                                'group'
+                                                                                            ) +
+                                                                                                (index +
+                                                                                                    1)}
+                                                                                        </MenuItem>
+                                                                                    )
+                                                                                )}
+                                                                            </Select>
+                                                                        </>
+                                                                    )}
+                                                                </TableCell>
+                                                            </TableRow>
+                                                        </TableHead>
+                                                        <TableBody>
+                                                            {loading ? (
+                                                                [
+                                                                    ...Array(3),
+                                                                ].map(
+                                                                    (
+                                                                        _,
+                                                                        index
+                                                                    ) => (
+                                                                        <Skeleton
+                                                                            key={
+                                                                                index
+                                                                            }
+                                                                            variant="text"
+                                                                            width={
+                                                                                '100%'
+                                                                            }
+                                                                            height={
+                                                                                50
+                                                                            }
+                                                                            sx={{
+                                                                                margin: 0,
+                                                                            }}
+                                                                        />
+                                                                    )
+                                                                )
+                                                            ) : (
+                                                                <>
+                                                                    {newGroups[
+                                                                        parseInt(
+                                                                            currentGroup
+                                                                        )
+                                                                    ] &&
+                                                                        newGroups[
+                                                                            parseInt(
+                                                                                currentGroup
+                                                                            )
+                                                                        ].studenten.map(
+                                                                            (
+                                                                                student
+                                                                            ) => (
+                                                                                <TableRow
+                                                                                    key={
+                                                                                        student
+                                                                                    }
+                                                                                >
+                                                                                    <TableCell
+                                                                                        sx={{
+                                                                                            height: 20,
+                                                                                            display:
+                                                                                                'flex',
+                                                                                            flexDirection:
+                                                                                                'row',
+                                                                                            justifyContent:
+                                                                                                'space-between',
+                                                                                            alignItems:
+                                                                                                'center',
+                                                                                        }}
+                                                                                    >
+                                                                                        {studentNames.get(
+                                                                                            student
+                                                                                        )}
+                                                                                        <IconButton // The teacher can remove students from the group by clicking on the cross icon
+                                                                                            onClick={() => {
+                                                                                                removeStudent(
+                                                                                                    student,
+                                                                                                    parseInt(
+                                                                                                        currentGroup
+                                                                                                    )
+                                                                                                )
+                                                                                            }}
+                                                                                        >
+                                                                                            <CancelIcon />
+                                                                                        </IconButton>
+                                                                                    </TableCell>
+                                                                                </TableRow>
+                                                                            )
+                                                                        )}
+                                                                </>
+                                                            )}
+                                                        </TableBody>
+                                                    </Table>
+                                                </TableContainer>
+                                            </Box>
+                                        </Box>
                                     </Box>
-                                </DialogActions>
+                                </Stack>
+                                <Box
+                                    aria-label={'save/cancel'}
+                                    sx={{
+                                        position: 'fixed',
+                                        bottom: 0,
+                                        width: '100%',
+                                        alignItems: 'flex-end',
+                                        gap: 5,
+                                        paddingRight: 10,
+                                    }}
+                                >
+                                    <DialogActions>
+                                        <Box
+                                            pr={5}
+                                            pb={5}
+                                            display={'flex'}
+                                            gap={1}
+                                        >
+                                            <Tooltip title={t('cancel')}>
+                                                <IconButton
+                                                    // The teacher can cancel the group changes by clicking on the cross icon.
+                                                    onClick={handleCancel}
+                                                    sx={{
+                                                        backgroundColor:
+                                                            'secondary.main',
+                                                        borderRadius: 2,
+                                                    }}
+                                                >
+                                                    <ClearIcon
+                                                        fontSize={'medium'}
+                                                    />
+                                                </IconButton>
+                                            </Tooltip>
+                                            <Tooltip title={t('submit')}>
+                                                {loading ? (
+                                                    <Skeleton
+                                                        variant={'rectangular'}
+                                                        width={40}
+                                                        height={40}
+                                                        sx={{
+                                                            backgroundColor:
+                                                                'primary.main',
+                                                            borderRadius: 2,
+                                                        }}
+                                                    />
+                                                ) : (
+                                                    <>
+                                                        <IconButton
+                                                            // The teacher can save the group changes by clicking on the save icon.type="submit"
+                                                            aria-label={
+                                                                'submit'
+                                                            }
+                                                            type={'submit'}
+                                                            sx={{
+                                                                backgroundColor:
+                                                                    'primary.main',
+                                                                borderRadius: 2,
+                                                                color: 'background.default',
+                                                                '&:hover': {
+                                                                    backgroundColor:
+                                                                        'secondary.main',
+                                                                    color: 'text.primary',
+                                                                },
+                                                            }}
+                                                        >
+                                                            <SaveIcon
+                                                                fontSize={
+                                                                    'medium'
+                                                                }
+                                                            />
+                                                        </IconButton>
+                                                    </>
+                                                )}
+                                            </Tooltip>
+                                        </Box>
+                                    </DialogActions>
+                                </Box>
                             </Box>
-                        </Box>
-                        {/* Warning popup for when the user wants to confirm the group changes */}
-                        <WarningPopup
-                            title={t('change_groups')}
-                            content={t('cant_be_undone')}
-                            buttonName={t('confirm')}
-                            open={confirmOpen}
-                            handleClose={handleCloseConfirm}
-                            doAction={confirmSave}
-                        />
-                    </>
-                ):(
-                    navigate('/course/' + courseId + '/assignment/' + assignmentId + '/groups/choose')
-                )}
-            </>
-        )} 
-    </>
-)}
+                            {/* Warning popup for when the user wants to confirm the group changes */}
+                            <WarningPopup
+                                title={t('change_groups')}
+                                content={t('cant_be_undone')}
+                                buttonName={t('confirm')}
+                                open={confirmOpen}
+                                handleClose={handleCloseConfirm}
+                                doAction={confirmSave}
+                            />
+                        </>
+                    ) : (
+                        navigate(
+                            '/course/' +
+                                courseId +
+                                '/assignment/' +
+                                assignmentId +
+                                '/groups/choose'
+                        )
+                    )}
+                </>
+            )}
+        </>
+    )
+}

--- a/frontend/frontend/src/routes.tsx
+++ b/frontend/frontend/src/routes.tsx
@@ -8,7 +8,7 @@ import ErrorPage from './pages/ErrorPage.tsx'
 import MainPage from './pages/mainPage/MainPage.tsx'
 import { GroupsPage } from './pages/groupsPage/GroupsPage.tsx'
 import { AssignmentPage } from './pages/assignmentPage/AssignmentPage.tsx'
-import {ChooseGroup} from "./pages/groupsPage/ChooseGroup.tsx";
+import { ChooseGroup } from './pages/groupsPage/ChooseGroup.tsx'
 
 //TODO: add change/add course page when implemented
 const router = createBrowserRouter([


### PR DESCRIPTION
refactor om groepen knop uit opgave pagina te krijgen en groepgrootte enkel aanpasbaar te maken bij het aanmaken van een project.
Dit vermindert de complexiteit in zowel de groeppagina als de backend.
We gaan hierdoor geen indieningen/groepen meer kwijtgeraken als er aanpassingen worden gedaan aan de groepgrootte.